### PR TITLE
feat: redesign reservations page with scheduling tools

### DIFF
--- a/padel-admin/src/app/features/reservations/pages/reservations-page/reservations-page.component.html
+++ b/padel-admin/src/app/features/reservations/pages/reservations-page/reservations-page.component.html
@@ -1,48 +1,724 @@
-<h2 class="mb-3">Reservas</h2>
+<div class="reservations-page">
+  <header class="page-header">
+    <div class="page-header__titles">
+      <h1>Reservas de canchas</h1>
+      <p class="subtitle">
+        Organizá tus turnos, pagá la seña y gestioná la disponibilidad en un único lugar.
+      </p>
+      <div class="selected-date" *ngIf="selectedDateLabel$ | async as selectedLabel">
+        <mat-icon>event</mat-icon>
+        <span>{{ selectedLabel }}</span>
+      </div>
+    </div>
+    <mat-button-toggle-group
+      class="role-toggle"
+      [value]="roleControl.value"
+      (change)="onChangeRole($event.value)"
+      aria-label="Seleccionar modo de visualización"
+    >
+      <mat-button-toggle value="player">Modo jugador</mat-button-toggle>
+      <mat-button-toggle value="admin">Modo administrador</mat-button-toggle>
+    </mat-button-toggle-group>
+  </header>
 
-<ng-container *ngIf="reservas$ | async as reservas">
-  <table mat-table [dataSource]="reservas" class="mat-elevation-z2">
+  <section class="filters" [formGroup]="filterForm">
+    <div class="filters__row">
+      <mat-button-toggle-group
+        class="view-toggle"
+        formControlName="viewMode"
+        aria-label="Cambiar la vista del calendario"
+      >
+        <mat-button-toggle *ngFor="let mode of viewModes" [value]="mode.value">
+          {{ mode.label }}
+        </mat-button-toggle>
+      </mat-button-toggle-group>
 
-    <ng-container matColumnDef="court">
-      <th mat-header-cell *matHeaderCellDef> Cancha </th>
-      <td mat-cell *matCellDef="let r"> {{ r.courtName }} </td>
-    </ng-container>
-
-    <ng-container matColumnDef="date">
-      <th mat-header-cell *matHeaderCellDef> Fecha </th>
-      <td mat-cell *matCellDef="let r"> {{ r.date | date:'dd/MM/yyyy' }} </td>
-    </ng-container>
-
-    <ng-container matColumnDef="time">
-      <th mat-header-cell *matHeaderCellDef> Horario </th>
-      <td mat-cell *matCellDef="let r"> {{ r.startTime }} - {{ r.endTime }} </td>
-    </ng-container>
-
-    <ng-container matColumnDef="players">
-      <th mat-header-cell *matHeaderCellDef> Jugadores </th>
-      <td mat-cell *matCellDef="let r"> {{ r.players.join(', ') }} </td>
-    </ng-container>
-
-    <ng-container matColumnDef="deposit">
-      <th mat-header-cell *matHeaderCellDef> Seña </th>
-      <td mat-cell *matCellDef="let r"> {{ r.deposit | currency:'ARS':'symbol' }} </td>
-    </ng-container>
-
-    <ng-container matColumnDef="status">
-      <th mat-header-cell *matHeaderCellDef> Estado </th>
-      <td mat-cell *matCellDef="let r"> {{ r.status }} </td>
-    </ng-container>
-
-    <ng-container matColumnDef="actions">
-      <th mat-header-cell *matHeaderCellDef> Acciones </th>
-      <td mat-cell *matCellDef="let r">
-        <button mat-icon-button (click)="cancel(r)">
-          <mat-icon>delete</mat-icon>
+      <div class="navigation-buttons">
+        <button
+          mat-icon-button
+          type="button"
+          (click)="navigate('prev')"
+          matTooltip="Ver periodo anterior"
+        >
+          <mat-icon>chevron_left</mat-icon>
         </button>
-      </td>
-    </ng-container>
+        <button mat-stroked-button type="button" (click)="onDateSelected(today)">
+          Hoy
+        </button>
+        <button
+          mat-icon-button
+          type="button"
+          (click)="navigate('next')"
+          matTooltip="Ver periodo siguiente"
+        >
+          <mat-icon>chevron_right</mat-icon>
+        </button>
+      </div>
+    </div>
 
-    <tr mat-header-row *matHeaderRowDef="cols"></tr>
-    <tr mat-row *matRowDef="let row; columns: cols;"></tr>
-  </table>
-</ng-container>
+    <div class="filters__row">
+      <mat-form-field appearance="outline">
+        <mat-label>Cancha</mat-label>
+        <mat-select formControlName="courtId">
+          <mat-option value="all">Todas las canchas</mat-option>
+          <mat-option *ngFor="let court of courts$ | async" [value]="court.id">
+            {{ court.name }}
+          </mat-option>
+        </mat-select>
+      </mat-form-field>
+
+      <mat-form-field appearance="outline">
+        <mat-label>Duración del turno</mat-label>
+        <mat-select formControlName="duration">
+          <mat-option [value]="null">Cualquier duración</mat-option>
+          <mat-option *ngFor="let option of durationOptions" [value]="option.value">
+            {{ option.label }}
+          </mat-option>
+        </mat-select>
+      </mat-form-field>
+
+      <mat-form-field appearance="outline">
+        <mat-label>Estado</mat-label>
+        <mat-select formControlName="status">
+          <mat-option *ngFor="let status of statusFilters" [value]="status.value">
+            {{ status.label }}
+          </mat-option>
+        </mat-select>
+      </mat-form-field>
+
+      <div class="date-range" formGroupName="range">
+        <mat-form-field appearance="outline">
+          <mat-label>Rango de fechas</mat-label>
+          <mat-date-range-input [rangePicker]="picker">
+            <input matStartDate formControlName="start" placeholder="Desde" />
+            <input matEndDate formControlName="end" placeholder="Hasta" />
+          </mat-date-range-input>
+          <mat-datepicker-toggle matSuffix [for]="picker"></mat-datepicker-toggle>
+          <mat-date-range-picker #picker></mat-date-range-picker>
+        </mat-form-field>
+      </div>
+
+      <mat-form-field appearance="outline" *ngIf="isAdmin$ | async">
+        <mat-label>Buscar reservas</mat-label>
+        <input matInput formControlName="search" placeholder="Nombre, email o cancha" />
+        <mat-icon matSuffix>search</mat-icon>
+      </mat-form-field>
+    </div>
+
+    <div class="policy-banner" *ngIf="depositPolicy$ | async as policy">
+      <mat-icon color="primary">info</mat-icon>
+      <span>{{ policy }}</span>
+    </div>
+  </section>
+
+  <mat-tab-group class="page-tabs">
+    <mat-tab label="Calendario">
+      <section class="calendar-section" *ngIf="(selectedDate$ | async) as selectedDate">
+        <mat-card class="calendar-section__calendar mat-elevation-z4">
+          <header class="card-header">
+            <div>
+              <h3>Calendario interactivo</h3>
+              <p>Colores en tiempo real para turnos disponibles, reservados y con seña pagada.</p>
+            </div>
+          </header>
+          <mat-calendar
+            [selected]="selectedDate"
+            (selectedChange)="onDateSelected($event)"
+            [dateClass]="calendarDateClass"
+          ></mat-calendar>
+          <div class="calendar-legend">
+            <div *ngFor="let item of calendarLegend" class="legend-item">
+              <span class="legend-dot" [ngClass]="item.class"></span>
+              <span>{{ item.label }}</span>
+            </div>
+          </div>
+
+          <section class="selected-day" *ngIf="selectedDateReservations$ | async as dayReservations">
+            <h4>Reservas para {{ selectedDate | date: 'EEEE d/M' }}</h4>
+            <p *ngIf="!dayReservations.length" class="empty-state">
+              No hay reservas registradas para este día. Seleccioná un horario disponible para comenzar.
+            </p>
+            <mat-list *ngIf="dayReservations.length">
+              <mat-list-item *ngFor="let reservation of dayReservations" [ngClass]="statusClass(reservation)">
+                <div matListItemIcon class="status-icon">
+                  <mat-icon *ngIf="reservation.status === 'bloqueada'">block</mat-icon>
+                  <mat-icon *ngIf="reservation.status === 'cancelada'">cancel</mat-icon>
+                  <mat-icon *ngIf="reservation.depositPaid && reservation.status !== 'bloqueada'">verified</mat-icon>
+                  <mat-icon *ngIf="!reservation.depositPaid && reservation.status !== 'bloqueada'">event_busy</mat-icon>
+                </div>
+                <div matListItemTitle>
+                  {{ reservation.startTime }} - {{ reservation.endTime }} · {{ reservation.courtName }}
+                </div>
+                <div matListItemLine>
+                  {{ reservation.contactName }} ·
+                  <strong>
+                    {{ statusLabels[reservation.status] }}
+                  </strong>
+                </div>
+                <div matListItemMeta>
+                  <span class="deposit-chip" [ngClass]="getDepositBadge(reservation)">
+                    Seña {{ getDepositBadge(reservation) === 'pagada' ? 'pagada' : 'pendiente' }}
+                  </span>
+                </div>
+              </mat-list-item>
+            </mat-list>
+          </section>
+        </mat-card>
+
+        <section class="calendar-section__details" [ngSwitch]="filterForm.controls.viewMode.value">
+          <ng-container *ngSwitchCase="'week'">
+            <mat-card class="mat-elevation-z2">
+              <header class="card-header">
+                <div>
+                  <h3>Vista semanal</h3>
+                  <p>Control total de las reservas y bloqueos para los próximos siete días.</p>
+                </div>
+              </header>
+              <div class="week-grid" *ngIf="weekOverview$ | async as overview">
+                <mat-card class="week-card" *ngFor="let day of overview">
+                  <h4>{{ day.label }}</h4>
+                  <div class="week-card__content" *ngIf="day.reservations.length; else emptyDay">
+                    <article
+                      class="week-card__reservation"
+                      *ngFor="let reservation of day.reservations"
+                      [ngClass]="statusClass(reservation)"
+                    >
+                      <header>
+                        <span class="time">{{ reservation.startTime }} - {{ reservation.endTime }}</span>
+                        <span class="court">{{ reservation.courtName }}</span>
+                      </header>
+                      <p>{{ reservation.contactName }}</p>
+                      <footer>
+                        <span class="deposit-chip" [ngClass]="getDepositBadge(reservation)">
+                          {{ reservation.deposit | currency: 'ARS':'symbol':'1.0-0' }} ·
+                          Seña {{ reservation.depositPaid ? 'pagada' : 'pendiente' }}
+                        </span>
+                      </footer>
+                    </article>
+                  </div>
+                  <ng-template #emptyDay>
+                    <p class="empty-state">Sin reservas aún.</p>
+                  </ng-template>
+                </mat-card>
+              </div>
+            </mat-card>
+          </ng-container>
+
+          <ng-container *ngSwitchCase="'day'">
+            <mat-card class="mat-elevation-z2 day-view">
+              <header class="card-header">
+                <div>
+                  <h3>Disponibilidad por cancha</h3>
+                  <p>Elegí un horario libre para completar la reserva en segundos.</p>
+                </div>
+              </header>
+              <ng-container *ngIf="dayAvailability$ | async as availability">
+                <mat-accordion multi>
+                  <mat-expansion-panel *ngFor="let courtAvailability of availability" [expanded]="true">
+                    <mat-expansion-panel-header>
+                      <mat-panel-title>
+                        {{ courtAvailability.court.name }}
+                      </mat-panel-title>
+                      <mat-panel-description>
+                        {{ courtAvailability.court.description }} · ${{ courtAvailability.court.pricePerHour | number: '1.0-0' }}/hora
+                      </mat-panel-description>
+                    </mat-expansion-panel-header>
+                    <div class="slot-list">
+                      <mat-chip-set aria-label="Turnos disponibles">
+                        <mat-chip
+                          *ngFor="let slot of courtAvailability.slots"
+                          [ngClass]="slot.status"
+                          [disabled]="slot.status !== 'available'"
+                          (click)="selectSlot(slot, courtAvailability.court, selectedDate)"
+                          [matTooltip]="slot.status === 'available' ? 'Reservar este horario' : (slot.reservation?.contactName || 'Ocupado')"
+                        >
+                          <mat-icon *ngIf="slot.status === 'available'">check_circle</mat-icon>
+                          <mat-icon *ngIf="slot.status === 'reserved'">event_busy</mat-icon>
+                          <mat-icon *ngIf="slot.status === 'deposit'">verified</mat-icon>
+                          <mat-icon *ngIf="slot.status === 'blocked'">block</mat-icon>
+                          <span>{{ slot.startTime }} - {{ slot.endTime }}</span>
+                        </mat-chip>
+                      </mat-chip-set>
+                    </div>
+                  </mat-expansion-panel>
+                </mat-accordion>
+              </ng-container>
+            </mat-card>
+          </ng-container>
+
+          <ng-container *ngSwitchDefault>
+            <mat-card class="mat-elevation-z2">
+              <header class="card-header">
+                <div>
+                  <h3>Resumen mensual</h3>
+                  <p>Visualizá rápidamente qué días tienen más movimiento y planificá tu agenda.</p>
+                </div>
+              </header>
+              <ng-container *ngIf="monthSummary$ | async as summary">
+                <p *ngIf="!summary.length" class="empty-state">
+                  Aún no hay reservas en este mes. Promocioná horarios libres para incrementar la ocupación.
+                </p>
+                <div class="month-summary" *ngIf="summary.length">
+                  <div class="month-summary__item" *ngFor="let day of summary">
+                    <span class="day">{{ day.date | date: 'd/M' }}</span>
+                    <span class="count">
+                      {{ day.count }} turno{{ day.count === 1 ? '' : 's' }}
+                    </span>
+                  </div>
+                </div>
+              </ng-container>
+            </mat-card>
+          </ng-container>
+        </section>
+      </section>
+
+      <section class="alerts" aria-label="Avisos y notificaciones">
+        <mat-card class="mat-elevation-z2" *ngIf="conflictWarnings$ | async as warnings">
+          <header class="card-header">
+            <div>
+              <h3>Alertas de conflictos</h3>
+              <p>Turnos superpuestos o bloqueados que requieren atención.</p>
+            </div>
+          </header>
+          <div *ngIf="warnings.length; else noConflicts">
+            <mat-list>
+              <mat-list-item *ngFor="let warning of warnings">
+                <mat-icon matListItemIcon color="warn">warning</mat-icon>
+                <div matListItemTitle>
+                  {{ warning.courtName }} · {{ warning.date | date: 'dd/MM/yyyy' }}
+                </div>
+                <div matListItemLine>
+                  {{ warning.reservations[0].startTime }} / {{ warning.reservations[1].startTime }} · Revisar disponibilidad
+                </div>
+              </mat-list-item>
+            </mat-list>
+          </div>
+          <ng-template #noConflicts>
+            <p class="empty-state">No se detectaron conflictos de agenda.</p>
+          </ng-template>
+        </mat-card>
+
+        <mat-card class="mat-elevation-z2" *ngIf="reminders$ | async as reminders">
+          <header class="card-header">
+            <div>
+              <h3>Recordatorios automáticos</h3>
+              <ng-container *ngIf="autoReminders$ | async; else remindersDisabled">
+                <p>Notificaremos a los jugadores antes del turno para completar el pago restante.</p>
+              </ng-container>
+            </div>
+          </header>
+          <div *ngIf="reminders.length; else noReminders">
+            <mat-list>
+              <mat-list-item *ngFor="let reminder of reminders">
+                <mat-icon matListItemIcon color="primary">notifications_active</mat-icon>
+                <div matListItemTitle>
+                  {{ reminder.reservation.contactName }} · {{ reminder.reservation.courtName }}
+                </div>
+                <div matListItemLine>
+                  Turno en {{ reminder.daysToGo }} día{{ reminder.daysToGo === 1 ? '' : 's' }} · {{ reminder.reservation.startTime }}
+                </div>
+              </mat-list-item>
+            </mat-list>
+          </div>
+          <ng-template #noReminders>
+            <p class="empty-state">Sin recordatorios pendientes por el momento.</p>
+          </ng-template>
+          <ng-template #remindersDisabled>
+            <p>Los recordatorios automáticos están desactivados. Activalos desde el panel de administración.</p>
+          </ng-template>
+        </mat-card>
+      </section>
+    </mat-tab>
+
+    <mat-tab label="Nueva reserva">
+      <section class="reservation-form" [formGroup]="reservationForm">
+        <mat-card class="mat-elevation-z2">
+          <header class="card-header">
+            <div>
+              <h3>Reservar un turno</h3>
+              <p>Completá los datos de contacto y confirmá la seña para asegurar tu lugar.</p>
+            </div>
+          </header>
+          <div class="form-grid">
+            <mat-form-field appearance="outline">
+              <mat-label>Cancha</mat-label>
+              <mat-select formControlName="courtId" required>
+                <mat-option *ngFor="let court of courts$ | async" [value]="court.id">
+                  {{ court.name }} · ${{ court.pricePerHour | number: '1.0-0' }}/h
+                </mat-option>
+              </mat-select>
+              <mat-error>Seleccioná una cancha</mat-error>
+            </mat-form-field>
+
+            <mat-form-field appearance="outline">
+              <mat-label>Fecha</mat-label>
+              <input matInput [matDatepicker]="reservationDate" formControlName="date" />
+              <mat-datepicker-toggle matSuffix [for]="reservationDate"></mat-datepicker-toggle>
+              <mat-datepicker #reservationDate></mat-datepicker>
+              <mat-error>Elegí la fecha del turno</mat-error>
+            </mat-form-field>
+
+            <mat-form-field appearance="outline">
+              <mat-label>Hora de inicio</mat-label>
+              <mat-select formControlName="startTime" required>
+                <mat-option *ngFor="let time of timeOptions" [value]="time">{{ time }}</mat-option>
+              </mat-select>
+              <mat-error>Indicá el horario de inicio</mat-error>
+            </mat-form-field>
+
+            <mat-form-field appearance="outline">
+              <mat-label>Duración</mat-label>
+              <mat-select formControlName="duration" required>
+                <mat-option *ngFor="let option of durationOptions" [value]="option.value">
+                  {{ option.label }}
+                </mat-option>
+              </mat-select>
+              <mat-error>Seleccioná la duración del turno</mat-error>
+            </mat-form-field>
+
+            <mat-form-field appearance="outline">
+              <mat-label>Nombre del responsable</mat-label>
+              <input matInput formControlName="contactName" placeholder="Nombre y apellido" />
+              <mat-error>Ingresá un nombre de contacto</mat-error>
+            </mat-form-field>
+
+            <mat-form-field appearance="outline">
+              <mat-label>Email de contacto</mat-label>
+              <input matInput formControlName="contactEmail" placeholder="nombre@correo.com" />
+              <mat-error>Ingresá un email válido</mat-error>
+            </mat-form-field>
+
+            <mat-form-field appearance="outline">
+              <mat-label>Jugadores</mat-label>
+              <textarea
+                matInput
+                formControlName="players"
+                placeholder="Ej: Ana, Bruno, Carla, Diego"
+                rows="3"
+              ></textarea>
+              <mat-error>Indicanos quiénes juegan</mat-error>
+            </mat-form-field>
+
+            <mat-form-field appearance="outline" class="notes">
+              <mat-label>Notas adicionales</mat-label>
+              <textarea matInput formControlName="notes" placeholder="Traigo invitados..." rows="3"></textarea>
+            </mat-form-field>
+
+            <mat-slide-toggle formControlName="payDeposit" color="primary">
+              Pagar seña ahora ({{ (depositPercentage$ | async)! * 100 | number: '1.0-0' }}%)
+            </mat-slide-toggle>
+          </div>
+
+          <section class="summary" *ngIf="reservationSummary$ | async as summary">
+            <mat-card class="summary-card mat-elevation-z1" [ngClass]="summary.isValid ? 'ready' : 'pending'">
+              <h4>Resumen de pago</h4>
+              <p *ngIf="!summary.isValid" class="empty-state">
+                Completá la cancha, horario y jugadores para calcular el monto de la seña.
+              </p>
+              <div *ngIf="summary.isValid" class="summary-grid">
+                <div>
+                  <span class="label">Cancha</span>
+                  <strong>{{ summary.courtName }}</strong>
+                </div>
+                <div>
+                  <span class="label">Horario</span>
+                  <strong>{{ reservationForm.value.startTime }} - {{ summary.endTime }}</strong>
+                </div>
+                <div>
+                  <span class="label">Monto total</span>
+                  <strong>{{ summary.total | currency: 'ARS':'symbol':'1.0-0' }}</strong>
+                </div>
+                <div>
+                  <span class="label">Seña ({{ summary.depositPercentage * 100 | number: '1.0-0' }}%)</span>
+                  <strong>{{ summary.deposit | currency: 'ARS':'symbol':'1.0-0' }}</strong>
+                </div>
+              </div>
+              <p *ngIf="summary.players.length" class="players">
+                Participantes: {{ summary.players.join(', ') }}
+              </p>
+            </mat-card>
+          </section>
+
+          <div class="form-actions">
+            <button
+              mat-flat-button
+              color="primary"
+              type="button"
+              (click)="reservationForm.controls.payDeposit.setValue(true); submitReservation()"
+            >
+              Reservar y pagar seña
+            </button>
+            <button
+              mat-stroked-button
+              color="accent"
+              type="button"
+              (click)="reservationForm.controls.payDeposit.setValue(false); submitReservation()"
+            >
+              Reservar sin pagar ahora
+            </button>
+          </div>
+        </mat-card>
+      </section>
+    </mat-tab>
+
+    <mat-tab label="Mis reservas">
+      <section class="my-reservations">
+        <mat-card class="mat-elevation-z2" *ngIf="myUpcomingReservations$ | async as upcoming">
+          <header class="card-header">
+            <div>
+              <h3 [matBadge]="upcoming.length" matBadgeColor="primary">Próximos turnos</h3>
+              <p>Gestioná cancelaciones, pagos de seña y recordatorios.</p>
+            </div>
+          </header>
+          <p *ngIf="!upcoming.length" class="empty-state">
+            No tenés reservas futuras. Elegí un horario disponible desde el calendario.
+          </p>
+          <table mat-table *ngIf="upcoming.length" [dataSource]="upcoming" [trackBy]="trackById" class="mat-elevation-z1">
+            <ng-container matColumnDef="date">
+              <th mat-header-cell *matHeaderCellDef>Fecha</th>
+              <td mat-cell *matCellDef="let reservation">
+                {{ reservation.date | date: 'dd/MM/yyyy' }}
+              </td>
+            </ng-container>
+            <ng-container matColumnDef="court">
+              <th mat-header-cell *matHeaderCellDef>Cancha</th>
+              <td mat-cell *matCellDef="let reservation">{{ reservation.courtName }}</td>
+            </ng-container>
+            <ng-container matColumnDef="time">
+              <th mat-header-cell *matHeaderCellDef>Horario</th>
+              <td mat-cell *matCellDef="let reservation">
+                {{ reservation.startTime }} - {{ reservation.endTime }}
+              </td>
+            </ng-container>
+            <ng-container matColumnDef="status">
+              <th mat-header-cell *matHeaderCellDef>Estado</th>
+              <td mat-cell *matCellDef="let reservation">
+                <span class="status-chip" [ngClass]="statusClass(reservation)">
+                  {{ statusLabels[reservation.status] }}
+                </span>
+              </td>
+            </ng-container>
+            <ng-container matColumnDef="deposit">
+              <th mat-header-cell *matHeaderCellDef>Seña</th>
+              <td mat-cell *matCellDef="let reservation">
+                <span class="deposit-chip" [ngClass]="getDepositBadge(reservation)">
+                  {{ reservation.deposit | currency: 'ARS':'symbol':'1.0-0' }}
+                </span>
+              </td>
+            </ng-container>
+            <ng-container matColumnDef="actions">
+              <th mat-header-cell *matHeaderCellDef>Acciones</th>
+              <td mat-cell *matCellDef="let reservation">
+                <button
+                  mat-icon-button
+                  color="primary"
+                  type="button"
+                  (click)="toggleReminder(reservation)"
+                  [matTooltip]="reservation.remindersSent ? 'Desactivar recordatorio' : 'Enviar recordatorio'"
+                >
+                  <mat-icon>{{ reservation.remindersSent ? 'notifications_off' : 'notifications_active' }}</mat-icon>
+                </button>
+                <button mat-icon-button color="warn" type="button" (click)="cancel(reservation)" matTooltip="Cancelar turno">
+                  <mat-icon>cancel</mat-icon>
+                </button>
+              </td>
+            </ng-container>
+            <tr mat-header-row *matHeaderRowDef="playerColumns"></tr>
+            <tr mat-row *matRowDef="let row; columns: playerColumns"></tr>
+          </table>
+        </mat-card>
+
+        <mat-card class="mat-elevation-z2" *ngIf="myHistoryReservations$ | async as history">
+          <header class="card-header">
+            <div>
+              <h3>Historial</h3>
+              <p>Consultá reservas pasadas, canceladas o completadas.</p>
+            </div>
+          </header>
+          <p *ngIf="!history.length" class="empty-state">Todavía no hay historial para mostrar.</p>
+          <table mat-table *ngIf="history.length" [dataSource]="history" [trackBy]="trackById" class="mat-elevation-z1">
+            <ng-container matColumnDef="date">
+              <th mat-header-cell *matHeaderCellDef>Fecha</th>
+              <td mat-cell *matCellDef="let reservation">{{ reservation.date | date: 'dd/MM/yyyy' }}</td>
+            </ng-container>
+            <ng-container matColumnDef="court">
+              <th mat-header-cell *matHeaderCellDef>Cancha</th>
+              <td mat-cell *matCellDef="let reservation">{{ reservation.courtName }}</td>
+            </ng-container>
+            <ng-container matColumnDef="time">
+              <th mat-header-cell *matHeaderCellDef>Horario</th>
+              <td mat-cell *matCellDef="let reservation">
+                {{ reservation.startTime }} - {{ reservation.endTime }}
+              </td>
+            </ng-container>
+            <ng-container matColumnDef="status">
+              <th mat-header-cell *matHeaderCellDef>Estado</th>
+              <td mat-cell *matCellDef="let reservation">
+                <span class="status-chip" [ngClass]="statusClass(reservation)">
+                  {{ statusLabels[reservation.status] }}
+                </span>
+              </td>
+            </ng-container>
+            <ng-container matColumnDef="deposit">
+              <th mat-header-cell *matHeaderCellDef>Seña</th>
+              <td mat-cell *matCellDef="let reservation">
+                {{ reservation.deposit | currency: 'ARS':'symbol':'1.0-0' }}
+              </td>
+            </ng-container>
+            <tr mat-header-row *matHeaderRowDef="historyColumns"></tr>
+            <tr mat-row *matRowDef="let row; columns: historyColumns"></tr>
+          </table>
+        </mat-card>
+      </section>
+    </mat-tab>
+
+    <mat-tab *ngIf="isAdmin$ | async" label="Administración">
+      <section class="admin-panel">
+        <mat-card class="mat-elevation-z2">
+          <header class="card-header">
+            <div>
+              <h3>Políticas y recordatorios</h3>
+              <p>Actualizá la seña, el mensaje visible para los usuarios y la automatización de avisos.</p>
+            </div>
+          </header>
+          <form class="admin-form" [formGroup]="policyForm">
+            <mat-form-field appearance="outline">
+              <mat-label>Porcentaje de seña</mat-label>
+              <input matInput type="number" formControlName="depositPercentage" min="0" max="100" />
+              <span matSuffix>%</span>
+              <mat-error>Ingresá un valor entre 0 y 100</mat-error>
+            </mat-form-field>
+            <mat-form-field appearance="outline" class="full-width">
+              <mat-label>Mensaje visible para jugadores</mat-label>
+              <textarea matInput formControlName="policyText" rows="3"></textarea>
+              <mat-error>El mensaje debe tener al menos 10 caracteres</mat-error>
+            </mat-form-field>
+            <mat-slide-toggle formControlName="autoReminders" color="primary">
+              Enviar recordatorios automáticos 24 h antes del turno
+            </mat-slide-toggle>
+            <button mat-flat-button color="primary" type="button" (click)="updatePolicies()">
+              Guardar cambios
+            </button>
+          </form>
+        </mat-card>
+
+        <mat-card class="mat-elevation-z2">
+          <header class="card-header">
+            <div>
+              <h3>Bloquear turnos</h3>
+              <p>Reservá espacios para mantenimiento, torneos o eventos especiales.</p>
+            </div>
+          </header>
+          <form class="admin-form" [formGroup]="blockForm">
+            <mat-form-field appearance="outline">
+              <mat-label>Cancha</mat-label>
+              <mat-select formControlName="courtId">
+                <mat-option *ngFor="let court of courts$ | async" [value]="court.id">
+                  {{ court.name }}
+                </mat-option>
+              </mat-select>
+              <mat-error>Seleccioná una cancha</mat-error>
+            </mat-form-field>
+            <mat-form-field appearance="outline">
+              <mat-label>Fecha</mat-label>
+              <input matInput [matDatepicker]="blockDate" formControlName="date" />
+              <mat-datepicker-toggle matSuffix [for]="blockDate"></mat-datepicker-toggle>
+              <mat-datepicker #blockDate></mat-datepicker>
+              <mat-error>Elegí una fecha</mat-error>
+            </mat-form-field>
+            <mat-form-field appearance="outline">
+              <mat-label>Hora de inicio</mat-label>
+              <mat-select formControlName="startTime">
+                <mat-option *ngFor="let time of timeOptions" [value]="time">{{ time }}</mat-option>
+              </mat-select>
+              <mat-error>Indicá el horario</mat-error>
+            </mat-form-field>
+            <mat-form-field appearance="outline">
+              <mat-label>Duración</mat-label>
+              <mat-select formControlName="duration">
+                <mat-option *ngFor="let option of durationOptions" [value]="option.value">{{ option.label }}</mat-option>
+              </mat-select>
+              <mat-error>Definí la duración</mat-error>
+            </mat-form-field>
+            <mat-form-field appearance="outline" class="full-width">
+              <mat-label>Motivo</mat-label>
+              <textarea matInput formControlName="reason" rows="2" placeholder="Mantenimiento, evento privado, etc."></textarea>
+            </mat-form-field>
+            <button mat-stroked-button color="primary" type="button" (click)="blockSlot()">
+              Bloquear turno
+            </button>
+          </form>
+        </mat-card>
+
+        <mat-card class="mat-elevation-z2" *ngIf="adminReservations$ | async as adminReservations">
+          <header class="card-header">
+            <div>
+              <h3>Reservas del club</h3>
+              <p>Filtrá por fecha, estado o cancha para gestionar todas las reservas.</p>
+            </div>
+          </header>
+          <p *ngIf="!adminReservations.length" class="empty-state">
+            No hay reservas que coincidan con los filtros seleccionados.
+          </p>
+          <table mat-table *ngIf="adminReservations.length" [dataSource]="adminReservations" [trackBy]="trackById" class="mat-elevation-z1">
+            <ng-container matColumnDef="court">
+              <th mat-header-cell *matHeaderCellDef>Cancha</th>
+              <td mat-cell *matCellDef="let reservation">{{ reservation.courtName }}</td>
+            </ng-container>
+            <ng-container matColumnDef="date">
+              <th mat-header-cell *matHeaderCellDef>Fecha</th>
+              <td mat-cell *matCellDef="let reservation">{{ reservation.date | date: 'dd/MM/yyyy' }}</td>
+            </ng-container>
+            <ng-container matColumnDef="time">
+              <th mat-header-cell *matHeaderCellDef>Horario</th>
+              <td mat-cell *matCellDef="let reservation">{{ reservation.startTime }} - {{ reservation.endTime }}</td>
+            </ng-container>
+            <ng-container matColumnDef="contact">
+              <th mat-header-cell *matHeaderCellDef>Contacto</th>
+              <td mat-cell *matCellDef="let reservation">
+                <div>{{ reservation.contactName }}</div>
+                <small>{{ reservation.contactEmail }}</small>
+              </td>
+            </ng-container>
+            <ng-container matColumnDef="deposit">
+              <th mat-header-cell *matHeaderCellDef>Pagos</th>
+              <td mat-cell *matCellDef="let reservation">
+                <span class="deposit-chip" [ngClass]="getDepositBadge(reservation)">
+                  Seña {{ reservation.depositPaid ? 'pagada' : 'pendiente' }}
+                </span>
+                <div class="total">Total: {{ reservation.totalPrice | currency: 'ARS':'symbol':'1.0-0' }}</div>
+              </td>
+            </ng-container>
+            <ng-container matColumnDef="status">
+              <th mat-header-cell *matHeaderCellDef>Estado</th>
+              <td mat-cell *matCellDef="let reservation">
+                <span class="status-chip" [ngClass]="statusClass(reservation)">
+                  {{ statusLabels[reservation.status] }}
+                </span>
+              </td>
+            </ng-container>
+            <ng-container matColumnDef="actions">
+              <th mat-header-cell *matHeaderCellDef>Acciones</th>
+              <td mat-cell *matCellDef="let reservation">
+                <button mat-icon-button color="primary" type="button" (click)="markDepositPaid(reservation)" matTooltip="Registrar seña">
+                  <mat-icon>paid</mat-icon>
+                </button>
+                <button mat-icon-button color="primary" type="button" (click)="markCompleted(reservation)" matTooltip="Marcar como completada">
+                  <mat-icon>done_all</mat-icon>
+                </button>
+                <button mat-icon-button color="primary" type="button" (click)="toggleReminder(reservation)" matTooltip="Alternar recordatorio">
+                  <mat-icon>{{ reservation.remindersSent ? 'notifications_off' : 'notifications_active' }}</mat-icon>
+                </button>
+                <button mat-icon-button color="warn" type="button" (click)="cancel(reservation)" matTooltip="Cancelar">
+                  <mat-icon>{{ reservation.status === 'bloqueada' ? 'lock_open' : 'cancel' }}</mat-icon>
+                </button>
+              </td>
+            </ng-container>
+            <tr mat-header-row *matHeaderRowDef="adminColumns"></tr>
+            <tr mat-row *matRowDef="let row; columns: adminColumns"></tr>
+          </table>
+        </mat-card>
+      </section>
+    </mat-tab>
+  </mat-tab-group>
+</div>

--- a/padel-admin/src/app/features/reservations/pages/reservations-page/reservations-page.component.scss
+++ b/padel-admin/src/app/features/reservations/pages/reservations-page/reservations-page.component.scss
@@ -1,6 +1,427 @@
-.mb-3 {
+:host {
+  display: block;
+  padding: 1.5rem;
+}
+
+.reservations-page {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.page-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 2rem;
+  flex-wrap: wrap;
+}
+
+.page-header__titles h1 {
+  margin: 0;
+  font-size: 2rem;
+}
+
+.subtitle {
+  margin: 0.25rem 0 1rem;
+  color: rgba(0, 0, 0, 0.6);
+}
+
+.role-toggle {
+  align-self: flex-end;
+}
+
+.selected-date {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.35rem 0.75rem;
+  border-radius: 999px;
+  background-color: rgba(63, 81, 181, 0.08);
+  color: #3f51b5;
+  font-weight: 500;
+}
+
+.filters {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  padding: 1rem;
+  border-radius: 1rem;
+  background-color: rgba(0, 0, 0, 0.03);
+}
+
+.filters__row {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1rem;
+  align-items: center;
+}
+
+.view-toggle {
+  justify-self: flex-start;
+}
+
+.navigation-buttons {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  justify-self: flex-end;
+}
+
+.policy-banner {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.75rem 1rem;
+  border-radius: 0.75rem;
+  background: rgba(255, 193, 7, 0.12);
+  color: rgba(0, 0, 0, 0.8);
+  font-size: 0.95rem;
+}
+
+.policy-banner mat-icon {
+  font-size: 1.5rem;
+}
+
+.calendar-section {
+  display: grid;
+  grid-template-columns: minmax(320px, 1fr) minmax(0, 2fr);
+  gap: 1.5rem;
+  margin-top: 1rem;
+}
+
+.calendar-section__calendar {
+  position: sticky;
+  top: 1.5rem;
+  align-self: flex-start;
+  padding-bottom: 1rem;
+}
+
+.calendar-legend {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  margin-top: 1rem;
+}
+
+.legend-item {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.85rem;
+  color: rgba(0, 0, 0, 0.7);
+}
+
+.legend-dot {
+  width: 0.75rem;
+  height: 0.75rem;
+  border-radius: 50%;
+  background-color: rgba(0, 0, 0, 0.2);
+  display: inline-block;
+}
+
+.legend-dot.available,
+.mat-calendar-body-cell.available .mat-calendar-body-cell-content,
+.slot-list .available.mat-mdc-standard-chip {
+  background-color: rgba(76, 175, 80, 0.12);
+  color: #2e7d32;
+}
+
+.legend-dot.reserved,
+.mat-calendar-body-cell.reserved .mat-calendar-body-cell-content,
+.slot-list .reserved.mat-mdc-standard-chip,
+.status-chip.reserved {
+  background-color: rgba(244, 67, 54, 0.12);
+  color: #c62828;
+}
+
+.legend-dot.deposit,
+.mat-calendar-body-cell.deposit .mat-calendar-body-cell-content,
+.slot-list .deposit.mat-mdc-standard-chip,
+.status-chip.deposit {
+  background-color: rgba(33, 150, 243, 0.12);
+  color: #1565c0;
+}
+
+.legend-dot.blocked,
+.mat-calendar-body-cell.blocked .mat-calendar-body-cell-content,
+.slot-list .blocked.mat-mdc-standard-chip,
+.status-chip.blocked {
+  background-color: rgba(158, 158, 158, 0.16);
+  color: #424242;
+}
+
+.status-chip.cancelled {
+  background-color: rgba(117, 117, 117, 0.14);
+  color: #616161;
+}
+
+.selected-day {
+  margin-top: 1.5rem;
+}
+
+.selected-day h4 {
+  margin-bottom: 0.5rem;
+}
+
+.selected-day .empty-state {
+  margin: 0.5rem 0;
+}
+
+.card-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
   margin-bottom: 1rem;
 }
+
+.card-header h3 {
+  margin: 0;
+}
+
+.card-header p {
+  margin: 0.25rem 0 0;
+  color: rgba(0, 0, 0, 0.6);
+}
+
+.week-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1rem;
+}
+
+.week-card {
+  padding: 1rem;
+  border-radius: 1rem;
+  background-color: rgba(0, 0, 0, 0.02);
+}
+
+.week-card__reservation {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  padding: 0.75rem;
+  border-radius: 0.75rem;
+  background-color: #fff;
+  margin-bottom: 0.75rem;
+  box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.05);
+}
+
+.week-card__reservation header {
+  display: flex;
+  justify-content: space-between;
+  font-weight: 600;
+}
+
+.week-card__reservation .court {
+  color: rgba(0, 0, 0, 0.6);
+}
+
+.week-card__reservation footer {
+  font-size: 0.85rem;
+  color: rgba(0, 0, 0, 0.7);
+}
+
+.day-view .slot-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  padding: 0.75rem 0 0.5rem;
+}
+
+.slot-list mat-chip {
+  --mdc-chip-elevated-container-color: transparent;
+  border-radius: 999px;
+  min-width: 120px;
+  justify-content: center;
+  gap: 0.25rem;
+  font-weight: 500;
+}
+
+.slot-list mat-chip[disabled] {
+  cursor: not-allowed;
+}
+
+.alerts {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 1.5rem;
+  margin: 2rem 0 1rem;
+}
+
+.reservation-form .form-grid {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  align-items: start;
+}
+
+.reservation-form .notes {
+  grid-column: 1 / -1;
+}
+
+.reservation-form .form-actions {
+  margin-top: 1.5rem;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+}
+
+.summary {
+  margin-top: 1.5rem;
+}
+
+.summary-card {
+  border-radius: 1rem;
+  padding: 1rem 1.25rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.summary-card.ready {
+  background-color: rgba(76, 175, 80, 0.12);
+}
+
+.summary-card.pending {
+  background-color: rgba(0, 0, 0, 0.04);
+}
+
+.summary-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  gap: 0.75rem;
+}
+
+.summary-grid .label {
+  display: block;
+  font-size: 0.85rem;
+  color: rgba(0, 0, 0, 0.6);
+}
+
+.players {
+  margin: 0;
+  font-size: 0.9rem;
+  color: rgba(0, 0, 0, 0.75);
+}
+
+.my-reservations,
+.admin-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.status-chip,
+.deposit-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  padding: 0.25rem 0.65rem;
+  border-radius: 999px;
+  font-size: 0.85rem;
+  font-weight: 600;
+  text-transform: none;
+}
+
+.deposit-chip.pagada {
+  background-color: rgba(76, 175, 80, 0.12);
+  color: #2e7d32;
+}
+
+.deposit-chip.pendiente {
+  background-color: rgba(255, 152, 0, 0.12);
+  color: #e65100;
+}
+
+.total {
+  margin-top: 0.25rem;
+  font-size: 0.8rem;
+  color: rgba(0, 0, 0, 0.6);
+}
+
+.empty-state {
+  margin: 0.5rem 0;
+  color: rgba(0, 0, 0, 0.6);
+  font-style: italic;
+}
+
+.admin-form {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1rem;
+  align-items: start;
+}
+
+.admin-form .full-width {
+  grid-column: 1 / -1;
+}
+
+.month-summary {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+  gap: 0.75rem;
+}
+
+.month-summary__item {
+  padding: 0.75rem;
+  border-radius: 0.75rem;
+  background-color: rgba(0, 0, 0, 0.04);
+  display: flex;
+  justify-content: space-between;
+  font-weight: 500;
+}
+
+.month-summary__item .day {
+  color: rgba(0, 0, 0, 0.6);
+}
+
 table {
   width: 100%;
+}
+
+table th {
+  text-transform: uppercase;
+  font-size: 0.75rem;
+  color: rgba(0, 0, 0, 0.54);
+}
+
+table td {
+  font-size: 0.9rem;
+}
+
+.status-icon mat-icon {
+  font-size: 1.5rem;
+}
+
+@media (max-width: 960px) {
+  .calendar-section {
+    grid-template-columns: 1fr;
+  }
+
+  .calendar-section__calendar {
+    position: relative;
+    top: 0;
+  }
+
+  .navigation-buttons {
+    justify-self: flex-start;
+  }
+}
+
+@media (max-width: 600px) {
+  :host {
+    padding: 1rem;
+  }
+
+  .page-header__titles h1 {
+    font-size: 1.75rem;
+  }
+
+  .reservation-form .form-actions {
+    flex-direction: column;
+    align-items: stretch;
+  }
 }

--- a/padel-admin/src/app/features/reservations/pages/reservations-page/reservations-page.component.spec.ts
+++ b/padel-admin/src/app/features/reservations/pages/reservations-page/reservations-page.component.spec.ts
@@ -1,4 +1,5 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 
 import { ReservationsPageComponent } from './reservations-page.component';
 
@@ -8,9 +9,8 @@ describe('ReservationsPageComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [ReservationsPageComponent]
-    })
-    .compileComponents();
+      imports: [ReservationsPageComponent, NoopAnimationsModule],
+    }).compileComponents();
     
     fixture = TestBed.createComponent(ReservationsPageComponent);
     component = fixture.componentInstance;

--- a/padel-admin/src/app/features/reservations/pages/reservations-page/reservations-page.component.ts
+++ b/padel-admin/src/app/features/reservations/pages/reservations-page/reservations-page.component.ts
@@ -1,34 +1,989 @@
-import { Component } from '@angular/core';
-import { Observable } from 'rxjs';
-import { Reservation } from '../../../../shared/models/reservation';
+import {
+  AsyncPipe,
+  CurrencyPipe,
+  DatePipe,
+  DecimalPipe,
+  NgClass,
+  NgFor,
+  NgIf,
+} from '@angular/common';
+import { Component, DestroyRef, inject } from '@angular/core';
+import {
+  FormBuilder,
+  FormControl,
+  ReactiveFormsModule,
+  Validators,
+} from '@angular/forms';
+import {
+  BehaviorSubject,
+  combineLatest,
+  map,
+  shareReplay,
+  startWith,
+} from 'rxjs';
+import {
+  Reservation,
+  ReservationStatus,
+} from '../../../../shared/models/reservation';
 import { ReservationService } from '../../services/reservation.service';
-import { AsyncPipe, CurrencyPipe, DatePipe, NgFor, NgIf } from '@angular/common';
+import { Court } from '../../../../shared/models/court';
 import { MatTableModule } from '@angular/material/table';
 import { MatButtonModule } from '@angular/material/button';
 import { MatIconModule } from '@angular/material/icon';
+import { MatTabsModule } from '@angular/material/tabs';
+import { MatButtonToggleModule } from '@angular/material/button-toggle';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatSelectModule } from '@angular/material/select';
+import { MatInputModule } from '@angular/material/input';
+import {
+  MatCalendarCellClassFunction,
+  MatDatepickerModule,
+} from '@angular/material/datepicker';
+import { MatNativeDateModule } from '@angular/material/core';
+import { MatChipsModule } from '@angular/material/chips';
+import { MatCardModule } from '@angular/material/card';
+import { MatListModule } from '@angular/material/list';
+import { MatSlideToggleModule } from '@angular/material/slide-toggle';
+import { MatTooltipModule } from '@angular/material/tooltip';
+import { MatBadgeModule } from '@angular/material/badge';
+import { MatExpansionModule } from '@angular/material/expansion';
+import { MatSnackBar, MatSnackBarModule } from '@angular/material/snack-bar';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+
+type CalendarViewMode = 'month' | 'week' | 'day';
+
+interface AvailabilitySlot {
+  startTime: string;
+  endTime: string;
+  status: 'available' | 'reserved' | 'deposit' | 'blocked';
+  reservation?: Reservation;
+}
+
+interface CourtAvailability {
+  court: Court;
+  slots: AvailabilitySlot[];
+}
+
+interface WeekDayOverview {
+  date: Date;
+  label: string;
+  reservations: Reservation[];
+}
+
+interface ConflictWarning {
+  courtName: string;
+  date: string;
+  reservations: [Reservation, Reservation];
+}
+
+interface ReminderItem {
+  reservation: Reservation;
+  daysToGo: number;
+}
+
+interface ReservationSummary {
+  isValid: boolean;
+  total: number;
+  deposit: number;
+  depositPercentage: number;
+  endTime?: string;
+  courtName?: string;
+  players: string[];
+}
+
+interface FilterFormValue {
+  viewMode: CalendarViewMode;
+  courtId: string;
+  duration: number | null;
+  status: 'all' | ReservationStatus;
+  range: { start: Date | null; end: Date | null } | null;
+  search: string | null;
+}
 
 @Component({
   selector: 'app-reservations-page',
   standalone: true,
   imports: [
     NgIf,
+    NgFor,
+    NgClass,
     AsyncPipe,
     DatePipe,
     CurrencyPipe,
+    DecimalPipe,
+    ReactiveFormsModule,
     MatTableModule,
     MatButtonModule,
     MatIconModule,
+    MatTabsModule,
+    MatButtonToggleModule,
+    MatFormFieldModule,
+    MatSelectModule,
+    MatInputModule,
+    MatDatepickerModule,
+    MatNativeDateModule,
+    MatChipsModule,
+    MatCardModule,
+    MatListModule,
+    MatSlideToggleModule,
+    MatTooltipModule,
+    MatBadgeModule,
+    MatExpansionModule,
+    MatSnackBarModule,
   ],
   templateUrl: './reservations-page.component.html',
   styleUrl: './reservations-page.component.scss',
 })
 export class ReservationsPageComponent {
-  reservas$: Observable<Reservation[]> = this.reservationService.reservas$;
-  cols = ['court', 'date', 'time', 'players', 'deposit', 'status', 'actions'];
+  private readonly reservationService = inject(ReservationService);
+  private readonly fb = inject(FormBuilder);
+  private readonly snackBar = inject(MatSnackBar);
+  private readonly destroyRef = inject(DestroyRef);
 
-  constructor(private reservationService: ReservationService) {}
+  readonly today = this.getStartOfDay(new Date());
+  readonly roleControl = new FormControl<'player' | 'admin'>('admin', {
+    nonNullable: true,
+  });
 
-  cancel(r: Reservation) {
-    this.reservationService.remove(r.id).subscribe();
+  readonly viewModes: { label: string; value: CalendarViewMode }[] = [
+    { label: 'Día', value: 'day' },
+    { label: 'Semana', value: 'week' },
+    { label: 'Mes', value: 'month' },
+  ];
+
+  readonly durationOptions = [
+    { label: '30 minutos', value: 30 },
+    { label: '1 hora', value: 60 },
+    { label: '1 h 30 min', value: 90 },
+    { label: '2 horas', value: 120 },
+  ];
+
+  readonly statusFilters: { label: string; value: 'all' | ReservationStatus }[] = [
+    { label: 'Todos', value: 'all' },
+    { label: 'Pendientes', value: 'pendiente' },
+    { label: 'Confirmadas', value: 'confirmada' },
+    { label: 'Completadas', value: 'completada' },
+    { label: 'Canceladas', value: 'cancelada' },
+    { label: 'Bloqueos', value: 'bloqueada' },
+  ];
+
+  readonly timeOptions = this.generateTimeOptions();
+
+  readonly filterForm = this.fb.group({
+    viewMode: this.fb.control<CalendarViewMode>('week', { nonNullable: true }),
+    courtId: this.fb.control<string>('all', { nonNullable: true }),
+    duration: this.fb.control<number | null>(60),
+    status: this.fb.control<'all' | ReservationStatus>('all', {
+      nonNullable: true,
+    }),
+    range: this.fb.group({
+      start: [this.today],
+      end: [this.today],
+    }),
+    search: this.fb.control<string>(''),
+  });
+
+  readonly reservationForm = this.fb.group({
+    courtId: ['', Validators.required],
+    date: [this.today, Validators.required],
+    startTime: [this.timeOptions[20], Validators.required],
+    duration: [60, Validators.required],
+    contactName: ['', Validators.required],
+    contactEmail: ['', [Validators.required, Validators.email]],
+    players: ['', Validators.required],
+    notes: [''],
+    payDeposit: [true],
+  });
+
+  readonly policyForm = this.fb.group({
+    depositPercentage: [30, [Validators.required, Validators.min(0), Validators.max(100)]],
+    policyText: ['', [Validators.required, Validators.minLength(10)]],
+    autoReminders: [true],
+  });
+
+  readonly blockForm = this.fb.group({
+    courtId: ['', Validators.required],
+    date: [this.today, Validators.required],
+    startTime: [this.timeOptions[0], Validators.required],
+    duration: [60, Validators.required],
+    reason: [''],
+  });
+
+  readonly reservas$ = this.reservationService.reservas$;
+  readonly courts$ = this.reservationService.courts$;
+  readonly depositPercentage$ = this.reservationService.depositPercentage$;
+  readonly depositPolicy$ = this.reservationService.depositPolicy$;
+  readonly autoReminders$ = this.reservationService.autoReminders$;
+
+  readonly playerColumns = ['date', 'court', 'time', 'status', 'deposit', 'actions'];
+  readonly historyColumns = ['date', 'court', 'time', 'status', 'deposit'];
+  readonly adminColumns = ['court', 'date', 'time', 'contact', 'deposit', 'status', 'actions'];
+
+  readonly calendarLegend = [
+    { label: 'Disponible', class: 'available' },
+    { label: 'Reservada', class: 'reserved' },
+    { label: 'Seña pagada', class: 'deposit' },
+    { label: 'Bloqueada', class: 'blocked' },
+  ];
+
+  private readonly currentUser = {
+    name: 'Dante Torres',
+    email: 'dante@example.com',
+  };
+
+  private reservationsSnapshot: Reservation[] = [];
+
+  private readonly selectedDateSubject = new BehaviorSubject<Date>(this.today);
+  readonly selectedDate$ = this.selectedDateSubject.asObservable();
+
+  readonly isAdmin$ = this.roleControl.valueChanges.pipe(
+    startWith(this.roleControl.value),
+    map((role) => role === 'admin'),
+    shareReplay(1)
+  );
+
+  private readonly filterValue$ = this.filterForm.valueChanges.pipe(
+    startWith(this.filterForm.getRawValue() as FilterFormValue)
+  );
+
+  readonly filteredReservations$ = combineLatest([
+    this.reservas$,
+    this.filterValue$,
+    this.roleControl.valueChanges.pipe(startWith(this.roleControl.value)),
+  ]).pipe(
+    map(([reservations, filters, role]) =>
+      this.applyFilters(reservations, filters, role)
+    ),
+    shareReplay(1)
+  );
+
+  readonly myUpcomingReservations$ = this.reservas$.pipe(
+    map((reservations) =>
+      reservations
+        .filter((reservation) =>
+          this.belongsToCurrentUser(reservation) &&
+          !this.isPastReservation(reservation) &&
+          reservation.status !== 'cancelada'
+        )
+        .sort((a, b) => this.compareReservations(a, b))
+    )
+  );
+
+  readonly myHistoryReservations$ = this.reservas$.pipe(
+    map((reservations) =>
+      reservations
+        .filter((reservation) =>
+          this.belongsToCurrentUser(reservation) &&
+          (this.isPastReservation(reservation) || reservation.status === 'cancelada')
+        )
+        .sort((a, b) => this.compareReservations(b, a))
+    )
+  );
+
+  readonly adminReservations$ = combineLatest([
+    this.filteredReservations$,
+    this.isAdmin$,
+  ]).pipe(
+    map(([reservations, isAdmin]) =>
+      isAdmin ? reservations : reservations.filter((r) => this.belongsToCurrentUser(r))
+    )
+  );
+
+  readonly conflictWarnings$ = this.reservas$.pipe(
+    map((reservations) => this.findConflicts(reservations))
+  );
+
+  readonly reminders$ = combineLatest([
+    this.reservas$,
+    this.autoReminders$,
+  ]).pipe(
+    map(([reservations, autoReminders]) =>
+      autoReminders ? this.buildReminderItems(reservations) : []
+    )
+  );
+
+  readonly weekOverview$ = combineLatest([
+    this.reservas$,
+    this.courts$,
+    this.selectedDate$,
+  ]).pipe(map(([reservations, courts, date]) => this.buildWeekOverview(reservations, courts, date)));
+
+  readonly dayAvailability$ = combineLatest([
+    this.reservas$,
+    this.courts$,
+    this.selectedDate$,
+    this.filterForm.controls.duration.valueChanges.pipe(
+      startWith(this.filterForm.controls.duration.value ?? 60)
+    ),
+    this.filterForm.controls.courtId.valueChanges.pipe(
+      startWith(this.filterForm.controls.courtId.value ?? 'all')
+    ),
+  ]).pipe(
+    map(([reservations, courts, date, duration, courtId]) =>
+      this.buildDayAvailability(reservations, courts, date, duration ?? 60, courtId)
+    )
+  );
+
+  readonly reservationSummary$ = combineLatest([
+    this.reservationForm.valueChanges.pipe(
+      startWith(this.reservationForm.getRawValue())
+    ),
+    this.depositPercentage$,
+    this.courts$,
+  ]).pipe(
+    map(([formValue, depositPercentage, courts]) =>
+      this.buildReservationSummary(formValue, depositPercentage, courts)
+    )
+  );
+
+  readonly selectedDateLabel$ = combineLatest([
+    this.selectedDate$,
+    this.filterForm.controls.viewMode.valueChanges.pipe(
+      startWith(this.filterForm.controls.viewMode.value)
+    ),
+  ]).pipe(
+    map(([date, mode]) => this.getSelectedDateLabel(date, mode))
+  );
+
+  readonly selectedDateReservations$ = combineLatest([
+    this.reservas$,
+    this.selectedDate$,
+  ]).pipe(
+    map(([reservations, date]) => {
+      const dateKey = this.toISODate(date);
+      return reservations
+        .filter((reservation) => reservation.date === dateKey)
+        .sort((a, b) => this.compareReservations(a, b));
+    })
+  );
+
+  readonly monthSummary$ = combineLatest([
+    this.reservas$,
+    this.selectedDate$,
+  ]).pipe(
+    map(([reservations, date]) => {
+      const month = date.getMonth() + 1;
+      const year = date.getFullYear();
+      const summary = new Map<string, number>();
+      reservations.forEach((reservation) => {
+        const [resYear, resMonth] = reservation.date
+          .split('-')
+          .map((value) => Number(value));
+        if (resYear === year && resMonth === month) {
+          summary.set(reservation.date, (summary.get(reservation.date) ?? 0) + 1);
+        }
+      });
+      return Array.from(summary.entries())
+        .map(([dateKey, count]) => ({
+          date: dateKey,
+          count,
+        }))
+        .sort((a, b) => a.date.localeCompare(b.date));
+    })
+  );
+
+  readonly trackById = (_: number, reservation: Reservation) => reservation.id;
+
+  readonly calendarDateClass: MatCalendarCellClassFunction<Date> = (
+    cellDate,
+    view
+  ) => {
+    if (view !== 'month') {
+      return '';
+    }
+    const dateKey = this.toISODate(cellDate);
+    const reservations = this.reservationsSnapshot.filter(
+      (reservation) => reservation.date === dateKey && reservation.status !== 'cancelada'
+    );
+    if (!reservations.length) {
+      return '';
+    }
+    if (reservations.some((reservation) => reservation.status === 'bloqueada')) {
+      return 'blocked';
+    }
+    if (reservations.some((reservation) => reservation.depositPaid)) {
+      return 'deposit';
+    }
+    return 'reserved';
+  };
+
+  readonly statusLabels: Record<ReservationStatus, string> = {
+    pendiente: 'Pendiente de seña',
+    confirmada: 'Confirmada',
+    completada: 'Completada',
+    cancelada: 'Cancelada',
+    bloqueada: 'Bloqueada por el club',
+  };
+
+  constructor() {
+    this.reservas$
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe((reservations) => (this.reservationsSnapshot = reservations));
+
+    combineLatest([this.depositPolicy$, this.depositPercentage$, this.autoReminders$])
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe(([policy, percentage, autoReminders]) => {
+        this.policyForm.patchValue(
+          {
+            policyText: policy,
+            depositPercentage: Math.round(percentage * 100),
+            autoReminders,
+          },
+          { emitEvent: false }
+        );
+      });
+  }
+
+  onChangeRole(role: 'player' | 'admin') {
+    this.roleControl.setValue(role, { emitEvent: true });
+  }
+
+  changeView(mode: CalendarViewMode) {
+    this.filterForm.controls.viewMode.setValue(mode);
+  }
+
+  navigate(direction: 'prev' | 'next') {
+    const mode = this.filterForm.controls.viewMode.value;
+    const currentDate = this.selectedDateSubject.value;
+    const newDate = new Date(currentDate);
+    switch (mode) {
+      case 'day':
+        newDate.setDate(currentDate.getDate() + (direction === 'next' ? 1 : -1));
+        break;
+      case 'week':
+        newDate.setDate(currentDate.getDate() + (direction === 'next' ? 7 : -7));
+        break;
+      case 'month':
+        newDate.setMonth(currentDate.getMonth() + (direction === 'next' ? 1 : -1));
+        break;
+    }
+    this.onDateSelected(newDate);
+  }
+
+  onDateSelected(date: Date) {
+    if (!date) {
+      return;
+    }
+    const normalized = this.getStartOfDay(date);
+    this.selectedDateSubject.next(normalized);
+    this.filterForm.controls.range.patchValue({ start: normalized, end: normalized });
+    this.reservationForm.controls.date.setValue(normalized);
+    this.blockForm.controls.date.setValue(normalized);
+  }
+
+  selectSlot(slot: AvailabilitySlot, court: Court, date: Date) {
+    if (slot.status !== 'available') {
+      if (slot.reservation) {
+        this.snackBar.open(
+          `Turno ocupado: ${slot.reservation.contactName} - ${this.statusLabels[slot.reservation.status]}`,
+          'Cerrar',
+          { duration: 3500 }
+        );
+      }
+      return;
+    }
+    this.reservationForm.patchValue({
+      courtId: court.id,
+      date,
+      startTime: slot.startTime,
+      duration: this.filterForm.controls.duration.value ?? 60,
+    });
+    this.snackBar.open(
+      `Turno seleccionado en ${court.name} a las ${slot.startTime}`,
+      'Completar datos',
+      { duration: 3500 }
+    );
+  }
+
+  submitReservation() {
+    if (this.reservationForm.invalid) {
+      this.reservationForm.markAllAsTouched();
+      return;
+    }
+
+    const value = this.reservationForm.getRawValue();
+    const court = this.reservationService.getCourtById(value.courtId ?? '');
+    if (!court || !value.date || !value.startTime) {
+      this.snackBar.open('Por favor seleccioná una cancha, fecha y horario válidos.', 'Cerrar', {
+        duration: 4000,
+      });
+      return;
+    }
+
+    const duration = value.duration ?? 60;
+    const endTime = this.addMinutesToTime(value.startTime, duration);
+    const players = value.players
+      ? value.players
+          .split(',')
+          .map((player) => player.trim())
+          .filter(Boolean)
+      : [];
+
+    const totalPrice = this.reservationService.calculatePrice(court.id, duration);
+    const deposit = this.reservationService.calculateDeposit(totalPrice);
+
+    const reservation: Reservation = {
+      id: this.generateId(),
+      courtId: court.id,
+      courtName: court.name,
+      date: this.toISODate(value.date),
+      startTime: value.startTime,
+      endTime,
+      durationMinutes: duration,
+      players,
+      contactName: value.contactName!,
+      contactEmail: value.contactEmail!,
+      notes: value.notes ?? undefined,
+      totalPrice,
+      deposit,
+      depositPaid: Boolean(value.payDeposit),
+      status: value.payDeposit ? 'confirmada' : 'pendiente',
+      remindersSent: false,
+      createdAt: new Date().toISOString(),
+    };
+
+    this.reservationService
+      .addReservation(reservation)
+      .subscribe(() => {
+        this.snackBar.open('Reserva creada. Recordá completar el pago restante.', 'OK', {
+          duration: 3500,
+        });
+        this.reservationForm.patchValue({
+          players: '',
+          notes: '',
+        });
+      });
+  }
+
+  cancel(reservation: Reservation) {
+    const message =
+      reservation.status === 'bloqueada'
+        ? '¿Quitar el bloqueo de la cancha para este turno?'
+        : '¿Cancelar la reserva seleccionada? Se aplicarán las políticas de cancelación.';
+    if (!confirm(message)) {
+      return;
+    }
+    const action =
+      reservation.status === 'bloqueada'
+        ? this.reservationService.remove(reservation.id)
+        : this.reservationService.cancelReservation(reservation.id);
+    action.subscribe(() => {
+      const label = reservation.status === 'bloqueada' ? 'Bloqueo eliminado' : 'Reserva cancelada';
+      this.snackBar.open(label, 'Cerrar', { duration: 3000 });
+    });
+  }
+
+  markDepositPaid(reservation: Reservation) {
+    this.reservationService.markDepositPaid(reservation.id).subscribe(() => {
+      this.snackBar.open('Se registró el pago de la seña.', 'Cerrar', {
+        duration: 3000,
+      });
+    });
+  }
+
+  markCompleted(reservation: Reservation) {
+    this.reservationService.markCompleted(reservation.id).subscribe(() => {
+      this.snackBar.open('Turno marcado como completado.', 'Cerrar', {
+        duration: 3000,
+      });
+    });
+  }
+
+  toggleReminder(reservation: Reservation) {
+    this.reservationService
+      .toggleReminder(reservation.id, !reservation.remindersSent)
+      .subscribe(() => {
+        const message = reservation.remindersSent
+          ? 'Se desactivó el recordatorio automático.'
+          : 'Recordatorio programado con éxito.';
+        this.snackBar.open(message, 'Cerrar', { duration: 3000 });
+      });
+  }
+
+  updatePolicies() {
+    if (this.policyForm.invalid) {
+      this.policyForm.markAllAsTouched();
+      return;
+    }
+    const { depositPercentage, policyText } = this.policyForm.getRawValue();
+    const percentage = Math.max(0, Math.min(100, depositPercentage ?? 0));
+    combineLatest([
+      this.reservationService.updateDepositPercentage(percentage / 100),
+      this.reservationService.updateDepositPolicy(policyText ?? ''),
+      this.reservationService.updateAutoReminders(Boolean(this.policyForm.value.autoReminders)),
+    ]).subscribe(() => {
+      this.snackBar.open('Políticas de seña actualizadas.', 'Cerrar', {
+        duration: 3000,
+      });
+    });
+  }
+
+  blockSlot() {
+    if (this.blockForm.invalid) {
+      this.blockForm.markAllAsTouched();
+      return;
+    }
+    const value = this.blockForm.getRawValue();
+    const court = this.reservationService.getCourtById(value.courtId ?? '');
+    if (!court || !value.date || !value.startTime) {
+      return;
+    }
+    const duration = value.duration ?? 60;
+    const endTime = this.addMinutesToTime(value.startTime, duration);
+    this.reservationService
+      .blockSlot({
+        courtId: court.id,
+        date: this.toISODate(value.date),
+        startTime: value.startTime,
+        endTime,
+        durationMinutes: duration,
+        reason: value.reason ?? undefined,
+      })
+      .subscribe(() => {
+        this.snackBar.open('Se bloqueó el turno seleccionado.', 'Cerrar', {
+          duration: 3000,
+        });
+      });
+  }
+
+  getDepositBadge(reservation: Reservation): 'pagada' | 'pendiente' {
+    if (reservation.status === 'bloqueada') {
+      return 'pagada';
+    }
+    return reservation.depositPaid ? 'pagada' : 'pendiente';
+  }
+
+  statusClass(reservation: Reservation): string {
+    if (reservation.status === 'bloqueada') {
+      return 'blocked';
+    }
+    if (reservation.status === 'cancelada') {
+      return 'cancelled';
+    }
+    return reservation.depositPaid ? 'deposit' : 'reserved';
+  }
+
+  private buildReservationSummary(
+    formValue: any,
+    depositPercentage: number,
+    courts: Court[]
+  ): ReservationSummary {
+    const { courtId, duration, startTime, players } = formValue;
+    const court = courts.find((item) => item.id === courtId);
+    if (!court || !duration || !startTime) {
+      return {
+        isValid: false,
+        total: 0,
+        deposit: 0,
+        depositPercentage,
+        players: [],
+      };
+    }
+    const total = this.reservationService.calculatePrice(court.id, duration);
+    const deposit = Math.round(total * depositPercentage);
+    const playerList = players
+      ? players
+          .split(',')
+          .map((player: string) => player.trim())
+          .filter(Boolean)
+      : [];
+    return {
+      isValid: true,
+      total,
+      deposit,
+      depositPercentage,
+      endTime: this.addMinutesToTime(startTime, duration),
+      courtName: court.name,
+      players: playerList,
+    };
+  }
+
+  private buildDayAvailability(
+    reservations: Reservation[],
+    courts: Court[],
+    date: Date,
+    duration: number,
+    courtId: string
+  ): CourtAvailability[] {
+    const dateKey = this.toISODate(date);
+    const filteredCourts = courtId === 'all' ? courts : courts.filter((court) => court.id === courtId);
+    return filteredCourts.map((court) => {
+      const slots = this.generateSlotsForCourt(reservations, court, dateKey, duration);
+      return { court, slots };
+    });
+  }
+
+  private buildWeekOverview(
+    reservations: Reservation[],
+    courts: Court[],
+    date: Date
+  ): WeekDayOverview[] {
+    const start = this.getStartOfWeek(date);
+    const overview: WeekDayOverview[] = [];
+    for (let index = 0; index < 7; index++) {
+      const current = new Date(start);
+      current.setDate(start.getDate() + index);
+      const dateKey = this.toISODate(current);
+      const dayReservations = reservations
+        .filter((reservation) => reservation.date === dateKey)
+        .filter((reservation) => reservation.status !== 'cancelada')
+        .sort((a, b) => this.compareReservations(a, b));
+      const label = this.formatDayLabel(current);
+      overview.push({ date: current, label, reservations: dayReservations });
+    }
+    return overview;
+  }
+
+  private buildReminderItems(reservations: Reservation[]): ReminderItem[] {
+    const now = new Date();
+    return reservations
+      .filter((reservation) => reservation.status !== 'cancelada')
+      .map((reservation) => {
+        const reservationDate = this.combineDateAndTime(reservation.date, reservation.startTime);
+        const diff = reservationDate.getTime() - now.getTime();
+        const days = Math.ceil(diff / (24 * 60 * 60 * 1000));
+        return { reservation, daysToGo: days };
+      })
+      .filter((item) => item.daysToGo >= 0 && item.daysToGo <= 3)
+      .sort((a, b) => a.daysToGo - b.daysToGo);
+  }
+
+  private applyFilters(
+    reservations: Reservation[],
+    filters: FilterFormValue,
+    role: 'player' | 'admin'
+  ): Reservation[] {
+    const range = filters.range ?? { start: null, end: null };
+    const start = range.start ? this.toISODate(range.start) : null;
+    const end = range.end ? this.toISODate(range.end) : null;
+    const search = (filters.search ?? '').trim().toLowerCase();
+
+    return reservations
+      .filter((reservation) => {
+        if (role === 'player' && !this.belongsToCurrentUser(reservation)) {
+          return false;
+        }
+        if (filters.courtId !== 'all' && reservation.courtId !== filters.courtId) {
+          return false;
+        }
+        if (filters.status !== 'all' && reservation.status !== filters.status) {
+          return false;
+        }
+        if (filters.duration && reservation.durationMinutes !== filters.duration) {
+          return false;
+        }
+        if (start && reservation.date < start) {
+          return false;
+        }
+        if (end && reservation.date > end) {
+          return false;
+        }
+        if (search) {
+          const haystack = [
+            reservation.contactName,
+            reservation.contactEmail,
+            reservation.players.join(', '),
+            reservation.courtName,
+            reservation.status,
+          ]
+            .join(' ')
+            .toLowerCase();
+          return haystack.includes(search);
+        }
+        return true;
+      })
+      .sort((a, b) => this.compareReservations(a, b));
+  }
+
+  private belongsToCurrentUser(reservation: Reservation): boolean {
+    return (
+      reservation.contactEmail.toLowerCase() === this.currentUser.email.toLowerCase() ||
+      reservation.players.some((player) => this.normalize(player) === this.normalize(this.currentUser.name))
+    );
+  }
+
+  private findConflicts(reservations: Reservation[]): ConflictWarning[] {
+    const warnings: ConflictWarning[] = [];
+    const active = reservations.filter((reservation) => reservation.status !== 'cancelada');
+    const sorted = active.sort((a, b) => this.compareReservations(a, b));
+    for (let i = 0; i < sorted.length; i++) {
+      for (let j = i + 1; j < sorted.length; j++) {
+        const first = sorted[i];
+        const second = sorted[j];
+        if (first.courtId !== second.courtId || first.date !== second.date) {
+          continue;
+        }
+        if (this.isTimeOverlap(first.startTime, first.endTime, second.startTime, second.endTime)) {
+          warnings.push({
+            courtName: first.courtName,
+            date: first.date,
+            reservations: [first, second],
+          });
+        }
+      }
+    }
+    return warnings;
+  }
+
+  private generateSlotsForCourt(
+    reservations: Reservation[],
+    court: Court,
+    date: string,
+    duration: number
+  ): AvailabilitySlot[] {
+    const sameDay = reservations.filter(
+      (reservation) =>
+        reservation.courtId === court.id &&
+        reservation.date === date &&
+        reservation.status !== 'cancelada'
+    );
+    const slots: AvailabilitySlot[] = [];
+    const step = 30;
+    const opening = 8 * 60;
+    const closing = 24 * 60;
+    const maxStart = closing - duration;
+    for (let minutes = opening; minutes <= maxStart; minutes += step) {
+      const startTime = this.minutesToTime(minutes);
+      const endTime = this.minutesToTime(minutes + duration);
+      const reservation = sameDay.find((item) =>
+        this.isTimeOverlap(item.startTime, item.endTime, startTime, endTime)
+      );
+      if (!reservation) {
+        slots.push({ startTime, endTime, status: 'available' });
+        continue;
+      }
+      const status: AvailabilitySlot['status'] =
+        reservation.status === 'bloqueada'
+          ? 'blocked'
+          : reservation.depositPaid
+          ? 'deposit'
+          : 'reserved';
+      slots.push({ startTime, endTime, status, reservation });
+    }
+    return slots;
+  }
+
+  private generateTimeOptions(): string[] {
+    const options: string[] = [];
+    for (let hour = 7; hour <= 23; hour++) {
+      options.push(`${hour.toString().padStart(2, '0')}:00`);
+      options.push(`${hour.toString().padStart(2, '0')}:30`);
+    }
+    return options;
+  }
+
+  private compareReservations(a: Reservation, b: Reservation): number {
+    if (a.date === b.date) {
+      return this.parseTime(a.startTime) - this.parseTime(b.startTime);
+    }
+    return a.date.localeCompare(b.date);
+  }
+
+  private parseTime(time: string): number {
+    const [hours, minutes] = time.split(':').map((value) => Number(value));
+    return hours * 60 + minutes;
+  }
+
+  private minutesToTime(minutes: number): string {
+    const hours = Math.floor(minutes / 60);
+    const rest = minutes % 60;
+    return `${hours.toString().padStart(2, '0')}:${rest.toString().padStart(2, '0')}`;
+  }
+
+  private addMinutesToTime(time: string, minutesToAdd: number): string {
+    const base = this.parseTime(time);
+    return this.minutesToTime(base + minutesToAdd);
+  }
+
+  private normalize(value: string): string {
+    return value.trim().toLowerCase();
+  }
+
+  private combineDateAndTime(date: string, time: string): Date {
+    return new Date(`${date}T${time}:00`);
+  }
+
+  private isPastReservation(reservation: Reservation): boolean {
+    const reservationDate = this.combineDateAndTime(
+      reservation.date,
+      reservation.endTime
+    );
+    return reservationDate.getTime() < Date.now();
+  }
+
+  private isTimeOverlap(
+    startA: string,
+    endA: string,
+    startB: string,
+    endB: string
+  ): boolean {
+    const startMinutesA = this.parseTime(startA);
+    const endMinutesA = this.parseTime(endA);
+    const startMinutesB = this.parseTime(startB);
+    const endMinutesB = this.parseTime(endB);
+    return startMinutesA < endMinutesB && startMinutesB < endMinutesA;
+  }
+
+  private getStartOfDay(date: Date): Date {
+    const normalized = new Date(date);
+    normalized.setHours(0, 0, 0, 0);
+    return normalized;
+  }
+
+  private toISODate(date: Date): string {
+    const year = date.getFullYear();
+    const month = (date.getMonth() + 1).toString().padStart(2, '0');
+    const day = date.getDate().toString().padStart(2, '0');
+    return `${year}-${month}-${day}`;
+  }
+
+  private getStartOfWeek(date: Date): Date {
+    const day = date.getDay();
+    const diff = day === 0 ? -6 : 1 - day;
+    const monday = new Date(date);
+    monday.setDate(date.getDate() + diff);
+    return this.getStartOfDay(monday);
+  }
+
+  private formatDayLabel(date: Date): string {
+    const formatter = new Intl.DateTimeFormat('es-AR', {
+      weekday: 'short',
+      month: 'short',
+      day: 'numeric',
+    });
+    return formatter.format(date);
+  }
+
+  private getSelectedDateLabel(date: Date, mode: CalendarViewMode): string {
+    const formatter = new Intl.DateTimeFormat('es-AR', {
+      month: 'long',
+      day: 'numeric',
+    });
+    if (mode === 'day') {
+      return formatter.format(date);
+    }
+    if (mode === 'week') {
+      const start = this.getStartOfWeek(date);
+      const end = new Date(start);
+      end.setDate(start.getDate() + 6);
+      const endFormatter = new Intl.DateTimeFormat('es-AR', {
+        month: 'long',
+        day: 'numeric',
+      });
+      return `${formatter.format(start)} - ${endFormatter.format(end)}`;
+    }
+    const monthFormatter = new Intl.DateTimeFormat('es-AR', {
+      month: 'long',
+      year: 'numeric',
+    });
+    return monthFormatter.format(date);
+  }
+
+  private generateId(): string {
+    const randomUUID = globalThis.crypto?.randomUUID?.();
+    if (randomUUID) {
+      return randomUUID;
+    }
+    return `res_${Date.now()}_${Math.floor(Math.random() * 10_000)}`;
   }
 }

--- a/padel-admin/src/app/features/reservations/services/reservation.service.ts
+++ b/padel-admin/src/app/features/reservations/services/reservation.service.ts
@@ -1,32 +1,271 @@
 import { Injectable } from '@angular/core';
 import { BehaviorSubject, Observable, of } from 'rxjs';
-import { Reservation } from '../../../shared/models/reservation';
+import { Court } from '../../../shared/models/court';
+import { Reservation, ReservationStatus } from '../../../shared/models/reservation';
+
+export interface BlockSlotPayload {
+  courtId: string;
+  date: string;
+  startTime: string;
+  endTime: string;
+  durationMinutes: number;
+  reason?: string;
+}
 
 @Injectable({ providedIn: 'root' })
 export class ReservationService {
+  private readonly _courts = new BehaviorSubject<Court[]>([
+    {
+      id: 'c1',
+      name: 'Cancha 1',
+      description: 'Exterior - Césped sintético profesional',
+      pricePerHour: 16000,
+      indoor: false,
+      hasLights: true,
+    },
+    {
+      id: 'c2',
+      name: 'Cancha 2',
+      description: 'Interior - Blindex y superficie rápida',
+      pricePerHour: 18500,
+      indoor: true,
+      hasLights: true,
+    },
+    {
+      id: 'c3',
+      name: 'Cancha 3',
+      description: 'Exterior - Ideal para torneos nocturnos',
+      pricePerHour: 15000,
+      indoor: false,
+      hasLights: true,
+    },
+  ]);
+
+  private readonly _depositPercentage = new BehaviorSubject<number>(0.3);
+
+  private readonly _depositPolicy = new BehaviorSubject<string>(
+    'La seña equivale al 30% del valor del turno. Si cancelás con más de 24 horas de anticipación, se reintegra el 100%. Pasado ese plazo, la seña se pierde.'
+  );
+
+  private readonly _autoReminders = new BehaviorSubject<boolean>(true);
+
   private readonly _reservas = new BehaviorSubject<Reservation[]>([
     {
       id: 'r1',
       courtId: 'c1',
       courtName: 'Cancha 1',
-      date: '2025-09-22',
+      date: '2025-05-05',
       startTime: '18:00',
-      endTime: '19:00',
-      players: ['Dante', 'Juan', 'Leo', 'Mati'],
-      deposit: 4000,
+      endTime: '19:30',
+      durationMinutes: 90,
+      players: ['Dante Torres', 'Juan Pérez', 'Leo Gómez', 'Mati Ruiz'],
+      contactName: 'Dante Torres',
+      contactEmail: 'dante@example.com',
+      notes: 'Traigo invitados',
+      totalPrice: 24000,
+      deposit: 7200,
+      depositPaid: true,
+      status: 'confirmada',
+      remindersSent: false,
+      createdAt: '2025-04-28T10:00:00.000Z',
+    },
+    {
+      id: 'r2',
+      courtId: 'c2',
+      courtName: 'Cancha 2',
+      date: '2025-05-05',
+      startTime: '20:00',
+      endTime: '21:00',
+      durationMinutes: 60,
+      players: ['Laura Medina', 'Sol Aguirre', 'Vicky López', 'Pao Díaz'],
+      contactName: 'Laura Medina',
+      contactEmail: 'laura@example.com',
+      totalPrice: 18500,
+      deposit: 5550,
+      depositPaid: false,
       status: 'pendiente',
+      remindersSent: false,
+      createdAt: '2025-04-27T18:30:00.000Z',
+      notes: 'Seña pendiente hasta mañana',
+    },
+    {
+      id: 'r3',
+      courtId: 'c2',
+      courtName: 'Cancha 2',
+      date: '2025-05-04',
+      startTime: '09:00',
+      endTime: '10:30',
+      durationMinutes: 90,
+      players: ['Club Torneos'],
+      contactName: 'Coordinación Liga',
+      contactEmail: 'liga@example.com',
+      totalPrice: 27750,
+      deposit: 8325,
+      depositPaid: true,
+      status: 'completada',
+      remindersSent: true,
+      createdAt: '2025-04-20T09:00:00.000Z',
+      updatedAt: '2025-05-04T13:30:00.000Z',
+    },
+    {
+      id: 'r4',
+      courtId: 'c3',
+      courtName: 'Cancha 3',
+      date: '2025-05-06',
+      startTime: '12:00',
+      endTime: '14:00',
+      durationMinutes: 120,
+      players: [],
+      contactName: 'Administración',
+      contactEmail: 'info@clubpadel.com',
+      totalPrice: 0,
+      deposit: 0,
+      depositPaid: true,
+      status: 'bloqueada',
+      remindersSent: false,
+      createdAt: '2025-04-25T08:00:00.000Z',
+      notes: 'Mantenimiento de la cancha',
     },
   ]);
 
-  reservas$: Observable<Reservation[]> = this._reservas.asObservable();
+  readonly reservas$: Observable<Reservation[]> = this._reservas.asObservable();
+  readonly courts$: Observable<Court[]> = this._courts.asObservable();
+  readonly depositPercentage$: Observable<number> = this._depositPercentage.asObservable();
+  readonly depositPolicy$: Observable<string> = this._depositPolicy.asObservable();
+  readonly autoReminders$: Observable<boolean> = this._autoReminders.asObservable();
 
-  add(reserva: Reservation) {
-    this._reservas.next([...this._reservas.value, reserva]);
-    return of(true);
+  get depositPercentage(): number {
+    return this._depositPercentage.value;
+  }
+
+  getCourtById(id: string): Court | undefined {
+    return this._courts.value.find((court) => court.id === id);
+  }
+
+  calculatePrice(courtId: string, durationMinutes: number): number {
+    const court = this.getCourtById(courtId);
+    if (!court) {
+      return 0;
+    }
+    return Math.round(((durationMinutes || 0) / 60) * court.pricePerHour);
+  }
+
+  calculateDeposit(totalPrice: number): number {
+    return Math.round(totalPrice * this._depositPercentage.value);
+  }
+
+  addReservation(reservation: Reservation) {
+    this._reservas.next([...this._reservas.value, reservation]);
+    return of(reservation);
+  }
+
+  updateReservation(id: string, changes: Partial<Reservation>) {
+    let updatedReservation: Reservation | undefined;
+    this._reservas.next(
+      this._reservas.value.map((reserva) => {
+        if (reserva.id !== id) {
+          return reserva;
+        }
+        updatedReservation = {
+          ...reserva,
+          ...changes,
+          updatedAt: new Date().toISOString(),
+        };
+        return updatedReservation;
+      })
+    );
+    return of(updatedReservation);
+  }
+
+  cancelReservation(id: string) {
+    return this.updateReservation(id, {
+      status: 'cancelada',
+      depositPaid: false,
+    });
   }
 
   remove(id: string) {
-    this._reservas.next(this._reservas.value.filter((r) => r.id !== id));
-    return of(true);
+    let removed = false;
+    this._reservas.next(
+      this._reservas.value.filter((reserva) => {
+        if (reserva.id === id) {
+          removed = true;
+        }
+        return reserva.id !== id;
+      })
+    );
+    return of(removed);
+  }
+
+  markDepositPaid(id: string) {
+    return this.updateReservation(id, {
+      depositPaid: true,
+      status: 'confirmada',
+    });
+  }
+
+  markCompleted(id: string) {
+    return this.updateReservation(id, {
+      status: 'completada',
+    });
+  }
+
+  toggleReminder(id: string, remindersSent: boolean) {
+    return this.updateReservation(id, { remindersSent });
+  }
+
+  blockSlot(payload: BlockSlotPayload) {
+    const court = this.getCourtById(payload.courtId);
+    if (!court) {
+      return of(undefined);
+    }
+    const reservation: Reservation = {
+      id: this.createId(),
+      courtId: payload.courtId,
+      courtName: court.name,
+      date: payload.date,
+      startTime: payload.startTime,
+      endTime: payload.endTime,
+      durationMinutes: payload.durationMinutes,
+      players: [],
+      contactName: 'Administración',
+      contactEmail: 'info@clubpadel.com',
+      notes: payload.reason,
+      totalPrice: 0,
+      deposit: 0,
+      depositPaid: true,
+      status: 'bloqueada',
+      remindersSent: false,
+      createdAt: new Date().toISOString(),
+    };
+    this._reservas.next([...this._reservas.value, reservation]);
+    return of(reservation);
+  }
+
+  updateDepositPercentage(percentage: number) {
+    this._depositPercentage.next(percentage);
+    return of(percentage);
+  }
+
+  updateDepositPolicy(policy: string) {
+    this._depositPolicy.next(policy);
+    return of(policy);
+  }
+
+  updateAutoReminders(enabled: boolean) {
+    this._autoReminders.next(enabled);
+    return of(enabled);
+  }
+
+  setReservationStatus(id: string, status: ReservationStatus) {
+    return this.updateReservation(id, { status });
+  }
+
+  private createId(): string {
+    const randomUUID = globalThis.crypto?.randomUUID?.();
+    if (randomUUID) {
+      return randomUUID;
+    }
+    return `res_${Date.now()}_${Math.floor(Math.random() * 10_000)}`;
   }
 }

--- a/padel-admin/src/app/shared/models/court.ts
+++ b/padel-admin/src/app/shared/models/court.ts
@@ -1,0 +1,8 @@
+export interface Court {
+  id: string;
+  name: string;
+  description: string;
+  pricePerHour: number;
+  indoor: boolean;
+  hasLights: boolean;
+}

--- a/padel-admin/src/app/shared/models/reservation.ts
+++ b/padel-admin/src/app/shared/models/reservation.ts
@@ -1,4 +1,9 @@
-export type ReservationStatus = 'pendiente' | 'confirmada' | 'cancelada';
+export type ReservationStatus =
+  | 'pendiente'
+  | 'confirmada'
+  | 'completada'
+  | 'cancelada'
+  | 'bloqueada';
 
 export interface Reservation {
   id: string;
@@ -7,7 +12,16 @@ export interface Reservation {
   date: string;
   startTime: string;
   endTime: string;
+  durationMinutes: number;
   players: string[];
+  contactName: string;
+  contactEmail: string;
+  notes?: string;
+  totalPrice: number;
   deposit: number;
+  depositPaid: boolean;
   status: ReservationStatus;
+  remindersSent: boolean;
+  createdAt: string;
+  updatedAt?: string;
 }


### PR DESCRIPTION
## Summary
- redesign the reservations page with Angular Material navigation, filters, and multi-view scheduling widgets for players and administradores
- extend reservation data and services to handle pricing, deposits, reminders, and court blocking with a reusable court model
- refresh the reservations page styles for responsive layouts, color-coded status indicators, and richer management panels

## Testing
- npm run build *(fails: ng not found before installing dependencies)*
- npm install *(fails: 403 fetching @angular-devkit/build-angular)*

------
https://chatgpt.com/codex/tasks/task_e_68d0828b517083229d14dcff7df2e76a